### PR TITLE
Optimize transformer loading in DocumentRAGSystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,3 +237,15 @@ Unit tests have been added for all major functions to ensure code reliability. T
 - `text_processing.py`: `split_text`
 
 These tests ensure that the system functions correctly and can handle various edge cases.
+
+### New Behavior: Skipping Transformer Model Initialization
+
+The `DocumentRAGSystem` class now checks if documents are already processed before initializing the transformer model. This optimization helps in reducing unnecessary loading of the transformer model, improving the system's efficiency.
+
+#### Updated Initialization
+
+The `__init__` method of `DocumentRAGSystem` now uses the `is_document_processed` function from `document_checker.py` to determine if the transformer model should be loaded. If all documents are already processed, the transformer model is not loaded during initialization.
+
+#### Ensuring Model Loading in `add_document`
+
+The `add_document` method in `document_rag.py` still checks if a document is already processed before adding it, but now it also ensures the transformer model is loaded if needed.


### PR DESCRIPTION
Update `DocumentRAGSystem` to skip transformer model initialization if documents are already processed.

* Modify `__init__` method in `document_rag.py` to check if documents are already processed before initializing the transformer model.
* Use `is_document_processed` function from `document_checker.py` to determine if the transformer model should be loaded.
* Add logic to ensure the transformer model is loaded if needed in the `add_document` method.
* Update `README.md` to reflect the new behavior of not loading the transformer model if documents are already processed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Xethrocc/DocRAG/pull/4?shareId=96d02c96-d125-44ae-abf2-835b79edd6f8).