### PR TITLE
Add FastAPI for API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The project has been organized into the following modules:
   - numpy
   - python-dotenv
   - tqdm
+  - fastapi
+  - uvicorn
 
 ## Requesty.ai Integration
 
@@ -249,3 +251,46 @@ The `__init__` method of `DocumentRAGSystem` now uses the `is_document_processed
 #### Ensuring Model Loading in `add_document`
 
 The `add_document` method in `document_rag.py` still checks if a document is already processed before adding it, but now it also ensures the transformer model is loaded if needed.
+
+### API Usage with FastAPI
+
+The system now includes a REST API using FastAPI to handle inputs and outputs. This allows other programs to interact with the Document RAG system through standardized API endpoints.
+
+#### Installation
+
+To use the FastAPI server, you need to install the following additional dependencies:
+
+```bash
+pip install fastapi uvicorn
+```
+
+#### Running the FastAPI Server
+
+You can run the FastAPI server using the following command:
+
+```bash
+python main.py --run_server
+```
+
+The server will start and listen for requests on `http://0.0.0.0:8000`.
+
+#### API Endpoints
+
+The FastAPI server provides the following endpoints:
+
+- `POST /process`: Process a new document and add it to the system
+- `POST /query`: Query the system with a search query
+
+#### Example Usage
+
+To process a new document, send a POST request to `/process` with the path to the PDF document:
+
+```bash
+curl -X POST "http://0.0.0.0:8000/process" -H "Content-Type: application/json" -d '{"pdf_path": "path/to/document.pdf"}'
+```
+
+To query the system, send a POST request to `/query` with the search query:
+
+```bash
+curl -X POST "http://0.0.0.0:8000/query" -H "Content-Type: application/json" -d '{"query": "Your question about the documents?"}'
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ numpy>=1.20.0
 tqdm>=4.65.0
 python-dotenv>=1.0.0
 openai>=0.27.0,<0.28.0
+fastapi>=0.68.0
+uvicorn>=0.15.0


### PR DESCRIPTION
Add REST API using FastAPI to handle inputs and outputs.

* **main.py**
  - Add `create_app` function to initialize FastAPI app.
  - Add `/process` endpoint to handle document processing requests.
  - Add `/query` endpoint to handle query requests.
  - Update `main` function to run the FastAPI app.
  - Add command-line argument `--run_server` to run the FastAPI server.

* **README.md**
  - Add section for API usage with FastAPI.
  - Update installation instructions to include FastAPI and Uvicorn.
  - Add instructions for running the FastAPI server.
  - Add details about API endpoints and example usage.

* **requirements.txt**
  - Add FastAPI and Uvicorn dependencies.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Xethrocc/DocRAG/pull/5?shareId=d4d74228-3d04-431f-bf46-347645570c88).