### PR TITLE
Add dynamic folder switching to Document RAG System

### DIFF
--- a/document_rag.py
+++ b/document_rag.py
@@ -1,5 +1,5 @@
 import os
-import numpy as np
+import numpy np
 import faiss
 import tiktoken
 import json
@@ -442,3 +442,27 @@ class DocumentRAGSystem:
         except Exception as e:
             logging.error(f"Error checking if document is processed: {str(e)}")
             return False
+
+    def switch_rag_folder(self, new_folder: str) -> None:
+        """
+        Switches the RAG folder and reloads the system state
+        
+        Parameters:
+        new_folder (str): Path to the new RAG folder
+        
+        Returns:
+        None
+        """
+        try:
+            # Check if the new folder exists
+            if not os.path.exists(new_folder):
+                raise FileNotFoundError(f"The folder {new_folder} does not exist.")
+            
+            # Load the system state from the new folder
+            self.load_system_state(new_folder)
+            
+            print(f"Switched to new RAG folder: {new_folder}")
+        except FileNotFoundError as e:
+            logging.error(f"File not found: {str(e)}")
+        except Exception as e:
+            logging.error(f"Error switching to new RAG folder {new_folder}: {str(e)}")

--- a/main.py
+++ b/main.py
@@ -38,6 +38,9 @@ class DocumentRequest(BaseModel):
 class QueryRequest(BaseModel):
     query: str
 
+class SwitchFolderRequest(BaseModel):
+    new_folder: str
+
 def create_app():
     app = FastAPI()
 
@@ -67,6 +70,17 @@ def create_app():
             llm_client = RequestyLLMClient(api_key=api_key)
             response = rag_system.generate_response(query=query, api_call_function=lambda prompt: llm_client.generate_response(prompt))
             return {"response": response}
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
+
+    @app.post("/switch_folder")
+    async def switch_folder(request: SwitchFolderRequest):
+        try:
+            new_folder = request.new_folder
+            from document_rag import DocumentRAGSystem
+            rag_system = DocumentRAGSystem(load_from=DEFAULT_RAG_DATA_DIR)
+            rag_system.switch_rag_folder(new_folder)
+            return {"message": f"Switched to new RAG folder: {new_folder}"}
         except Exception as e:
             raise HTTPException(status_code=500, detail=str(e))
 


### PR DESCRIPTION
Add functionality to switch the RAG folder dynamically and update the system state.

* **document_rag.py**
  - Add `switch_rag_folder` method to `DocumentRAGSystem` class to switch the RAG folder and reload the system state.
  - Handle exceptions for file not found and other errors during the folder switch.

* **main.py**
  - Add `SwitchFolderRequest` class to handle the new folder path in the request.
  - Add new API endpoint `/switch_folder` to handle requests for switching the RAG folder.
  - Implement logic to switch the folder and reload the system state within the new endpoint.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Xethrocc/DocRAG/pull/6?shareId=e05f367a-072b-4f49-9e79-d9f31d4f87c5).